### PR TITLE
Fix uninitialized rgDMAMap tail in CreateDMATables

### DIFF
--- a/src/atari8.vm/xvideo.c
+++ b/src/atari8.vm/xvideo.c
@@ -535,6 +535,14 @@ void CreateDMATables()
                                 // This is what wLeft should start at for this kind of line (plus one, since wLeft is one-based)
                                 rgDMAMap[mode][pf][width][first][player][missile][lms][HCLOCKS] = cycle - 1;
 
+                                // The loop above stops after this line type's N free cycles,
+                                // leaving array[N..HCLOCKS-1] unwritten. Fill the tail so stack
+                                // garbage is never copied into rgDMAMap (a mid-line DMAMAP
+                                // variant switch can index past N; values >= 113 then reads
+                                // past rgPIXELMap and corrupts cclock).
+                                for (int tail = cycle; tail < HCLOCKS; tail++)
+                                    array[tail] = 0;
+
                                 // copy the temp array over to the permanent array
                                 for (cycle = 0; cycle < HCLOCKS; cycle++)
                                 {


### PR DESCRIPTION
`CreateDMATables` builds per-variant DMA lookup tables via a backward cycle-conversion loop
that breaks early after N free cycles for DMA-contended scan-line variants, leaving
`array[N..HCLOCKS-1]` as uninitialized stack memory. That entire array is then copied into
`rgDMAMap`. Mid-line DMAMAP variant switches (iscan advance flipping the `[first]`
dimension, or a DMACTL write switching to a roomier variant) can index into the uninitialized
tail; values ≥ 113 reach past `rgPIXELMap` into `rgPMGMap`, producing impossible `cclock`
values that cause double PSLPostpare fires, lost scan lines, and DLI timing corruption.
This patch inserts a zero-fill of `array[cycle..HCLOCKS-1]` between the build loop and the
copy loop. The fill is a no-op for fully-free scan-line variants where the build loop runs
to completion.

Fixes softmac/xformer10#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
